### PR TITLE
[ 2주차 과제 ] 특강 신청 서비스 - 심화과제

### DIFF
--- a/src/main/kotlin/com/hhplus/lecture/domain/lecture/Lecture.kt
+++ b/src/main/kotlin/com/hhplus/lecture/domain/lecture/Lecture.kt
@@ -30,6 +30,7 @@ class Lecture(
 
     fun subscribe(userInfo: UserInfo) {
         check(subscriptionCount < MAX_SUBSCRIPTION_COUNT) { "특강 신청 인원이 초과되었습니다." }
+        check(subscriptions.none { it.userId == userInfo.id }) { "이미 신청한 특강입니다." }
 
         subscriptions.add(LectureSubscription(this, userInfo.id))
         subscriptionCount++

--- a/src/main/kotlin/com/hhplus/lecture/domain/lecture/LectureSubscription.kt
+++ b/src/main/kotlin/com/hhplus/lecture/domain/lecture/LectureSubscription.kt
@@ -4,7 +4,10 @@ import com.hhplus.lecture.infrastructure.BaseEntity
 import jakarta.persistence.*
 
 @Entity
-@Table(name = "lecture_subscription")
+@Table(
+    name = "lecture_subscription",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["lecture_id", "userId"])]
+)
 class LectureSubscription(
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "lecture_id", nullable = false, foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))

--- a/src/test/kotlin/com/hhplus/lecture/domain/lecture/LectureTest.kt
+++ b/src/test/kotlin/com/hhplus/lecture/domain/lecture/LectureTest.kt
@@ -52,6 +52,27 @@ class LectureTest {
     }
 
     @Test
+    fun `같은 사용자가 이미 신청한 특강에 재신청할 수 없다`() {
+        // given
+        val lecture = Instancio.of(Lecture::class.java)
+            .set(field(Lecture::subscriptionCount), 0)
+            .set(field(Lecture::subscriptions), mutableListOf<LectureSubscription>())
+            .create()
+
+        val userInfo = Instancio.of(UserInfo::class.java)
+            .set(field(UserInfo::id), 123L)
+            .create()
+        lecture.subscribe(userInfo)
+
+        // when then
+        assertThatThrownBy {
+            lecture.subscribe(userInfo)
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("이미 신청한 특강입니다.")
+    }
+
+    @Test
     fun `특강 신청 시 신청자 목록에 추가된다`() {
         // given
         val lecture = Instancio.of(Lecture::class.java)


### PR DESCRIPTION
### **커밋 링크**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

- 같은 사용자가 동일한 특강에 대해 신청 성공하지 못하도록 개선 및 테스트 작성 : 9c6319b9be5531524ddc63bb4281ff27084543e4

---
### **리뷰 포인트(질문)**

- 특강 신청 Service 메서드에 진입하여 동일한 사용자가 동일한 특강을 신청하려고 하면, 이미 해당 특강으로 조회 시 비관적 쓰기 락을 수행하기에 이미 동일한 특강에 대해 순차 처리가 보장되어 있어 동시성 문제가 없습니다. 특강 신청 Entity인 `LectureSubscription` 테이블에는 락이 걸리지 않고도 동시성 처리가 성공한 것인데, 괜찮은 구현 방법이라고 보시나요?
- 혹시 모르는 경우 등을 대비하여 확실하게 Unique Key Constraint로 이중 방어(?)를 수행했습니다. 저는 데이터 정합성을 위해 실무에서도 유일성을 보장해야 하는 경우면 Applicaton에서 동시성 처리가 되어있더라도 웬만해서는 꼭 Unique Key Constraint를 추가해 두는 편인데, 이에 대한 생각은 어떠신지 궁금합니다.

<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->
꾸준히 열심히 한 점

### Problem
<!--개선이 필요한 점-->
크게 중요하지 않은 외부 설정에 시간을 많이 소모한 점

### Try
<!-- 새롭게 시도할 점 -->
조금 더 효율적으로 과제를 수행할 방법 고민